### PR TITLE
Cozy atmosphere + procedural audio, migrate to Zig 0.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Install dependencies
         run: |
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Build for Windows
         run: zig build -Dtarget=x86_64-windows -Doptimize=ReleaseFast

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ zig-cache/
 
 # Performance metrics logs
 logs/
+# Dev screenshot output (BT_SHOOT)
+bt_shot.png
+
+# Zig 0.16 local package cache
+zig-pkg/

--- a/README.md
+++ b/README.md
@@ -4,13 +4,34 @@ Buzzness Tycoon is a simple game that I'm working on to learn Zig and have an ex
 
 ## Concept
 
-The game revolves around an isometric grid where flowers grow and potentially wither to make space for new ones. The player's task is to manage bees, collecting pollen to produce honey. Bees have a limited lifespan, so you'll need to invest in creating new bees as the older ones die off. The game ends if all your bees die and there's no pollen left to collect. I plan to implement an upgrade system to enhance the gameplay further.
+A chill, cozy idle game. On an isometric floating meadow, bees drift between flowers gathering pollen and carrying it back to the hive to make honey. Spend honey in the shop and upgrade tree to unlock faster bees, bigger grids, labs, and prestige — then sit back and watch the little world hum along.
+
+## Ambience & feel
+
+The meadow is meant to be relaxing to leave running:
+
+- **Day/night cycle** — a slow (~5 min) dawn → day → dusk → night loop with a gradient sky, drifting clouds, a rising/setting sun, a soft moon and a twinkling star field. The whole scene is lit by the current time of day.
+- **A living world** — bees bob and buzz with soft shadows, flowers sway in the breeze and cast shadows, the hive gently breathes, and pollen-laden bees glow.
+- **Fireflies** — daytime pollen dust warms into glowing fireflies at night.
+- **Procedural audio** — a gentle synthesized music-box loop plus soft pentatonic chimes when honey is delivered. No sample assets; it's all generated at startup.
+
+## Controls
+
+- **Mouse** — drag to pan, scroll to zoom, click tiles/flowers/bubbles to interact, use the side panel to buy.
+- **B / M** — activate Burst / Bloom labs (once unlocked).
+- **N** — mute / unmute audio.
+- **Esc** — close popups / open the pause menu.
+- **Alt+Enter** — toggle fullscreen.
+
+Dev/debug env vars: `BT_WINDOWED=1` launches in a window instead of fullscreen; `BT_AUTOPLAY=1` skips the title screen; `BT_PHASE=0..1` freezes the time of day; `BT_SHOOT=N` renders N frames, writes `bt_shot.png`, then exits.
 
 ## Screenshot
 
 ![Buzzness Tycoon Screenshot](.github/game.png)
 
 ## Build
+
+Requires **Zig 0.16** (uses `raylib-zig` 6.0.0).
 
 You can use debug for vscode if you have the C/C++ extension. 
 

--- a/build.zig
+++ b/build.zig
@@ -27,13 +27,13 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
-    exe.linkLibrary(raylib_artifact);
+    exe.root_module.linkLibrary(raylib_artifact);
     exe.root_module.addImport("raylib", raylib);
     exe.root_module.addImport("raygui", raygui);
     exe.root_module.addImport("sprites", sprites_module);
 
     // Add path to the sprites directory for @embedFile
-    exe.addIncludePath(b.path(".")); // Makes the project root accessible
+    exe.root_module.addIncludePath(b.path(".")); // Makes the project root accessible
 
     b.installArtifact(exe);
 
@@ -57,7 +57,7 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
-    exe_check.linkLibrary(raylib_artifact);
+    exe_check.root_module.linkLibrary(raylib_artifact);
     exe_check.root_module.addImport("raylib", raylib);
     exe_check.root_module.addImport("raygui", raygui);
     exe_check.root_module.addImport("sprites", sprites_module);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{ .name = .buzznesstycoon, .version = "0.0.0", .dependencies = .{
     .raylib_zig = .{
-        .url = "git+https://github.com/raylib-zig/raylib-zig?ref=devel#3cd4d3179d967fc8b931514603fdbc4a43a1d771",
-        .hash = "raylib_zig-5.6.0-dev-KE8REE1LBQCL7lia-DwUkusWI1G4kJmhtatLh2kNsuiE",
+        .url = "git+https://github.com/raylib-zig/raylib-zig?ref=devel#97be2c7ae646a2f09856604b138c427c0af1b952",
+        .hash = "raylib_zig-6.0.0-KE8REDJ4BQBu7lKwYNt6R4j5ywPeS37zqW6zrtjCcRwH",
     },
 }, .paths = .{
     "build.zig",

--- a/src/ambient.zig
+++ b/src/ambient.zig
@@ -1,0 +1,88 @@
+const rl = @import("raylib");
+const std = @import("std");
+
+/// Screen-space ambient motes: drifting pollen dust by day that warms into
+/// glowing, blinking fireflies at night. Purely decorative — floats in the
+/// "air" over the meadow and never touches gameplay. Confined to the play area
+/// (left of the side panel).
+pub const Ambient = struct {
+    const COUNT = 90;
+
+    const Mote = struct {
+        x: f32,
+        y: f32,
+        vx: f32,
+        vy: f32,
+        size: f32,
+        phase: f32,
+        blinkRate: f32,
+    };
+
+    motes: [COUNT]Mote,
+    seeded: bool = false,
+
+    fn lcg(state: *u32) f32 {
+        state.* = state.* *% 1664525 +% 1013904223;
+        return @as(f32, @floatFromInt(state.* >> 8)) / @as(f32, @floatFromInt(1 << 24));
+    }
+
+    pub fn init() Ambient {
+        return .{ .motes = undefined, .seeded = false };
+    }
+
+    fn seed(self: *Ambient, w: f32, h: f32) void {
+        var rng: u32 = 0x1234abcd;
+        for (&self.motes) |*m| {
+            m.x = lcg(&rng) * w;
+            m.y = lcg(&rng) * h;
+            m.vx = (lcg(&rng) - 0.5) * 14.0;
+            m.vy = -(6.0 + lcg(&rng) * 12.0); // drift gently upward
+            m.size = 1.0 + lcg(&rng) * 2.0;
+            m.phase = lcg(&rng) * std.math.tau;
+            m.blinkRate = 0.8 + lcg(&rng) * 1.6;
+        }
+        self.seeded = true;
+    }
+
+    pub fn update(self: *Ambient, dt: f32, playW: f32, playH: f32) void {
+        if (!self.seeded) self.seed(playW, playH);
+        const time = @as(f32, @floatCast(rl.getTime()));
+        for (&self.motes) |*m| {
+            // Lazy sine sway on top of the base drift so paths look organic.
+            m.x += (m.vx + @sin(time * 0.6 + m.phase) * 6.0) * dt;
+            m.y += m.vy * dt;
+            // Wrap around the play area.
+            if (m.y < -8) {
+                m.y = playH + 8;
+                m.x = @mod(m.x + 137.0, playW);
+            }
+            if (m.x < -8) m.x = playW + 8;
+            if (m.x > playW + 8) m.x = -8;
+        }
+    }
+
+    /// nightFactor in [0,1] blends pollen-dust → firefly behaviour.
+    pub fn draw(self: *const Ambient, nightFactor: f32) void {
+        const time = @as(f32, @floatCast(rl.getTime()));
+        // Day: pale warm pollen. Night: glowing amber fireflies.
+        const day = rl.Color.init(255, 244, 200, 255);
+        const nite = rl.Color.init(190, 255, 150, 255);
+        const col = rl.colorLerp(day, nite, nightFactor);
+
+        for (self.motes) |m| {
+            // Fireflies blink slowly and strongly; daytime dust barely shimmers.
+            const blink = 0.5 + 0.5 * @sin(time * m.blinkRate + m.phase);
+            const dayAlpha = 0.12 + 0.10 * blink;
+            const niteAlpha = blink * blink * 0.9;
+            const a = std.math.clamp(dayAlpha * (1.0 - nightFactor) + niteAlpha * nightFactor, 0.0, 1.0);
+            if (a <= 0.02) continue;
+
+            const r = m.size * (1.0 + nightFactor * 0.6);
+            // Soft glow halo (stronger at night), plus a bright core.
+            if (nightFactor > 0.1) {
+                rl.drawCircleGradient(rl.Vector2.init(m.x, m.y), r * 4.0, rl.colorAlpha(col, a * 0.35 * nightFactor), rl.colorAlpha(col, 0));
+            }
+            rl.drawCircleV(rl.Vector2.init(m.x, m.y), r, rl.colorAlpha(col, a));
+        }
+    }
+};

--- a/src/audio.zig
+++ b/src/audio.zig
@@ -1,0 +1,190 @@
+const rl = @import("raylib");
+const std = @import("std");
+
+/// Procedurally-synthesized cozy audio. No sample assets: a gentle ambient
+/// music-box loop (soft drone + pentatonic bells) and a gathering chime that
+/// plays when bees deliver honey. Everything degrades gracefully if there is
+/// no audio device (headless / no server) — `ready` gates all playback.
+pub const Audio = struct {
+    const SAMPLE_RATE: u32 = 44100;
+    const A_MIN_PENTATONIC = [_]f32{ 220.0, 261.63, 293.66, 329.63, 392.0, 440.0, 523.25, 587.33 };
+
+    ready: bool,
+    music: rl.Sound,
+    chime: rl.Sound,
+    chimeCooldown: f32,
+    chimeIndex: usize,
+    muted: bool,
+
+    pub fn init(allocator: std.mem.Allocator) Audio {
+        rl.initAudioDevice();
+        var self: Audio = .{
+            .ready = rl.isAudioDeviceReady(),
+            .music = undefined,
+            .chime = undefined,
+            .chimeCooldown = 0,
+            .chimeIndex = 0,
+            .muted = false,
+        };
+        if (!self.ready) return self;
+
+        rl.setMasterVolume(0.7);
+        self.music = buildMusic(allocator) catch {
+            self.ready = false;
+            return self;
+        };
+        self.chime = buildChime(allocator) catch {
+            rl.unloadSound(self.music);
+            self.ready = false;
+            return self;
+        };
+        rl.setSoundVolume(self.music, 0.32);
+        rl.setSoundVolume(self.chime, 0.28);
+        rl.playSound(self.music);
+        return self;
+    }
+
+    pub fn deinit(self: *Audio) void {
+        if (self.ready) {
+            rl.unloadSound(self.music);
+            rl.unloadSound(self.chime);
+        }
+        if (rl.isAudioDeviceReady()) rl.closeAudioDevice();
+    }
+
+    pub fn toggleMute(self: *Audio) void {
+        self.muted = !self.muted;
+        rl.setMasterVolume(if (self.muted) 0.0 else 0.7);
+    }
+
+    pub fn update(self: *Audio, dt: f32) void {
+        if (!self.ready) return;
+        // Loop the ambient bed by relaunching it once it finishes.
+        if (!rl.isSoundPlaying(self.music)) rl.playSound(self.music);
+        if (self.chimeCooldown > 0) self.chimeCooldown -= dt;
+    }
+
+    /// Soft bell when honey is delivered. Throttled and pitch-cycled through a
+    /// pentatonic scale so a busy hive sounds like wind chimes, not a machine gun.
+    pub fn playCollect(self: *Audio) void {
+        if (!self.ready or self.chimeCooldown > 0) return;
+        const ratios = [_]f32{ 1.0, 1.2, 1.5, 1.8, 2.0 };
+        rl.setSoundPitch(self.chime, ratios[self.chimeIndex % ratios.len]);
+        rl.playSound(self.chime);
+        self.chimeIndex +%= 1;
+        self.chimeCooldown = 0.16;
+    }
+
+    // ---- synthesis ----------------------------------------------------------
+
+    fn waveFromSamples(samples: []i16) rl.Wave {
+        return .{
+            .frameCount = @intCast(samples.len),
+            .sampleRate = SAMPLE_RATE,
+            .sampleSize = 16,
+            .channels = 1,
+            .data = @ptrCast(samples.ptr),
+        };
+    }
+
+    /// A ~16s ambient loop: two low detuned drones under a sparse pentatonic
+    /// bell melody. Envelope fades both ends to zero so the loop point is silent
+    /// (no click). Returns a Sound; the temp sample buffer is freed after load
+    /// because raylib copies the wave into its own audio buffer.
+    fn buildMusic(allocator: std.mem.Allocator) !rl.Sound {
+        const dur_s: f32 = 16.0;
+        const n: usize = @intFromFloat(dur_s * @as(f32, @floatFromInt(SAMPLE_RATE)));
+        const buf = try allocator.alloc(i16, n);
+        defer allocator.free(buf);
+        const acc = try allocator.alloc(f32, n);
+        defer allocator.free(acc);
+        @memset(acc, 0);
+
+        const sr: f32 = @floatFromInt(SAMPLE_RATE);
+
+        // Low drone: A2 + E3, slow tremolo — the warm "bed".
+        for (0..n) |i| {
+            const t = @as(f32, @floatFromInt(i)) / sr;
+            const trem = 0.85 + 0.15 * @sin(t * std.math.tau * 0.08);
+            var s: f32 = 0;
+            s += @sin(t * std.math.tau * 110.0) * 0.16;
+            s += @sin(t * std.math.tau * 164.81) * 0.11;
+            s += @sin(t * std.math.tau * 220.02) * 0.06; // gentle detune shimmer
+            acc[i] += s * trem;
+        }
+
+        // Sparse bell melody over the loop. Each note is a decaying sine pair
+        // (fundamental + octave) for a soft music-box timbre.
+        const melody = [_]struct { start: f32, note: usize, amp: f32 }{
+            .{ .start = 0.5, .note = 5, .amp = 0.22 },
+            .{ .start = 2.5, .note = 4, .amp = 0.18 },
+            .{ .start = 4.0, .note = 6, .amp = 0.20 },
+            .{ .start = 6.0, .note = 3, .amp = 0.17 },
+            .{ .start = 8.0, .note = 5, .amp = 0.22 },
+            .{ .start = 10.0, .note = 7, .amp = 0.19 },
+            .{ .start = 11.5, .note = 4, .amp = 0.16 },
+            .{ .start = 13.0, .note = 2, .amp = 0.18 },
+            .{ .start = 14.5, .note = 5, .amp = 0.15 },
+        };
+        for (melody) |m| {
+            addBell(acc, m.start, A_MIN_PENTATONIC[m.note], m.amp, 2.2, sr);
+        }
+
+        // Global fade in/out so the loop seam is silent.
+        applyLoopFade(acc, sr, 0.6);
+        floatToI16(acc, buf);
+
+        const wave = waveFromSamples(buf);
+        const sound = rl.loadSoundFromWave(wave);
+        return sound;
+    }
+
+    /// A single short pentatonic bell — used for honey pickups, retuned per play.
+    fn buildChime(allocator: std.mem.Allocator) !rl.Sound {
+        const dur_s: f32 = 0.6;
+        const n: usize = @intFromFloat(dur_s * @as(f32, @floatFromInt(SAMPLE_RATE)));
+        const buf = try allocator.alloc(i16, n);
+        defer allocator.free(buf);
+        const acc = try allocator.alloc(f32, n);
+        defer allocator.free(acc);
+        @memset(acc, 0);
+
+        const sr: f32 = @floatFromInt(SAMPLE_RATE);
+        addBell(acc, 0.0, 523.25, 0.5, 0.5, sr); // C5 base; pitch-shifted at play
+        floatToI16(acc, buf);
+
+        const wave = waveFromSamples(buf);
+        return rl.loadSoundFromWave(wave);
+    }
+
+    /// Add a decaying sine bell (fundamental + soft octave) into `acc` at `start`.
+    fn addBell(acc: []f32, start: f32, freq: f32, amp: f32, decay_s: f32, sr: f32) void {
+        const startIdx: usize = @intFromFloat(start * sr);
+        if (startIdx >= acc.len) return;
+        var i: usize = startIdx;
+        while (i < acc.len) : (i += 1) {
+            const t = @as(f32, @floatFromInt(i - startIdx)) / sr;
+            const env = std.math.exp(-t / (decay_s * 0.35));
+            if (env < 0.001) break;
+            const s = (@sin(t * std.math.tau * freq) * 0.7 + @sin(t * std.math.tau * freq * 2.0) * 0.3);
+            acc[i] += s * env * amp;
+        }
+    }
+
+    fn applyLoopFade(acc: []f32, sr: f32, fade_s: f32) void {
+        const fn_: usize = @intFromFloat(fade_s * sr);
+        const n = acc.len;
+        for (0..@min(fn_, n)) |i| {
+            const g = @as(f32, @floatFromInt(i)) / @as(f32, @floatFromInt(fn_));
+            acc[i] *= g;
+            acc[n - 1 - i] *= g;
+        }
+    }
+
+    fn floatToI16(acc: []const f32, buf: []i16) void {
+        for (acc, 0..) |v, i| {
+            const clamped = std.math.clamp(v, -1.0, 1.0);
+            buf[i] = @intFromFloat(clamped * 32000.0);
+        }
+    }
+};

--- a/src/ecs/systems/render_system.zig
+++ b/src/ecs/systems/render_system.zig
@@ -54,9 +54,11 @@ pub fn resetCaches() void {
     beeRenderCount = 0;
 }
 
-pub fn draw(world: *World, gridOffset: rl.Vector2, gridScale: f32) !void {
+pub fn draw(world: *World, gridOffset: rl.Vector2, gridScale: f32, worldTint: rl.Color) !void {
     cachedScreenWidth = @floatFromInt(rl.getScreenWidth());
     cachedScreenHeight = @floatFromInt(rl.getScreenHeight());
+
+    const time = @as(f32, @floatCast(rl.getTime()));
 
     if (cachedBeehive == null) {
         var beehiveIter = world.entityToBeehive.keyIterator();
@@ -78,10 +80,11 @@ pub fn draw(world: *World, gridOffset: rl.Vector2, gridScale: f32) !void {
     }
 
     if (cachedBeehive) |bh| {
-        drawBeehiveAtGridPosition(bh.texture, bh.gridX, bh.gridY, bh.width, bh.height, bh.scale, gridOffset, gridScale);
+        // Soft ground shadow + a gentle "breathing" pulse so the hive feels alive.
+        drawGroundShadow(bh.gridX, bh.gridY, gridOffset, gridScale, 0.6, 0.28);
+        const pulse = bh.scale * (1.0 + 0.03 * @sin(time * 1.4));
+        drawBeehiveAtGridPosition(bh.texture, bh.gridX, bh.gridY, bh.width, bh.height, pulse, gridOffset, gridScale, worldTint);
     }
-
-    const time = @as(f32, @floatCast(rl.getTime()));
 
     var flowerList: [512]FlowerRenderData = undefined;
     var flowerCount: usize = 0;
@@ -115,11 +118,23 @@ pub fn draw(world: *World, gridOffset: rl.Vector2, gridScale: f32) !void {
             if (world.getSprite(flowerData.entity)) |sprite| {
                 const source = rl.Rectangle.init(growth.state * sprite.width, 0, sprite.width, sprite.height);
 
+                // Grown flowers are taller → they sway more. Per-flower phase from
+                // grid position keeps the meadow from swaying in lockstep.
+                const growthFrac = growth.state / 4.0;
+                const phase = flowerData.gridX * 1.7 + flowerData.gridY * 0.9;
+                const sway = @sin(time * 0.9 + phase) * 2.6 * growthFrac;
+
+                // Ground shadow, scaled with how grown the flower is.
+                drawGroundShadow(flowerData.gridX, flowerData.gridY, gridOffset, gridScale, 0.34 + 0.14 * growthFrac, 0.22);
+
                 if (growth.state == 4 and growth.hasPollen) {
-                    drawSpriteAtGridPosition(sprite.texture, flowerData.gridX, flowerData.gridY, source, sprite.scale + 0.1, theme.CatppuccinMocha.Color.pollenGlow, gridOffset, gridScale);
+                    // Pollen glow breathes and stays bright (untinted) so ready
+                    // flowers pop, even at night.
+                    const glowPulse = 0.1 + 0.05 * @sin(time * 3.0 + phase);
+                    drawSpriteAtGridPosition(sprite.texture, flowerData.gridX, flowerData.gridY, source, sprite.scale + glowPulse, theme.CatppuccinMocha.Color.pollenGlow, gridOffset, gridScale, sway);
                 }
 
-                drawSpriteAtGridPosition(sprite.texture, flowerData.gridX, flowerData.gridY, source, sprite.scale, rl.Color.white, gridOffset, gridScale);
+                drawSpriteAtGridPosition(sprite.texture, flowerData.gridX, flowerData.gridY, source, sprite.scale, worldTint, gridOffset, gridScale, sway);
 
                 if (flowerData.isDying) {
                     drawRebirthBubble(flowerData.gridX, flowerData.gridY, gridOffset, gridScale, time);
@@ -143,10 +158,44 @@ pub fn draw(world: *World, gridOffset: rl.Vector2, gridScale: f32) !void {
         const pollenColor = theme.CatppuccinMocha.Color.yellow;
         for (0..beeRenderCount) |i| {
             const bee = beeRenderList[i];
-            const color = if (bee.carryingPollen) pollenColor else bee.color;
-            rl.drawTextureEx(texture, rl.Vector2.init(bee.x, bee.y), 0, bee.scale, color);
+            const phase = @as(f32, @floatFromInt(i)) * 0.7;
+
+            // Slow float bob + fast wing "buzz" scale flutter = alive, cozy bees.
+            const bob = @sin(time * 2.0 + phase) * 2.2 * bee.scale;
+            const buzz = 1.0 + 0.06 * @sin(time * 26.0 + phase);
+            const drawScale = bee.scale * buzz;
+            const cx = bee.x + 16 * bee.scale;
+
+            // Ground shadow stays near the resting baseline; it shrinks and fades
+            // as the bee floats higher, selling the vertical motion.
+            const lift = std.math.clamp(-bob / (3.0 * bee.scale), -1.0, 1.0);
+            const shadowScale = 1.0 - 0.25 * lift;
+            drawEllipseSoft(cx, bee.y + 26 * bee.scale, 8.5 * bee.scale * shadowScale, 3.2 * bee.scale * shadowScale, @intFromFloat(60 * (1.0 - 0.35 * lift)));
+
+            // Pollen-carriers get a warm glow so laden bees are easy to track.
+            if (bee.carryingPollen) {
+                rl.drawCircleGradient(rl.Vector2.init(cx, bee.y + bob + 14 * bee.scale), 16 * bee.scale, rl.Color.init(255, 226, 120, 90), rl.Color.init(255, 226, 120, 0));
+            }
+
+            const base = if (bee.carryingPollen) pollenColor else bee.color;
+            const color = rl.colorTint(base, worldTint);
+            rl.drawTextureEx(texture, rl.Vector2.init(bee.x, bee.y + bob), 0, drawScale, color);
         }
     }
+}
+
+/// Soft translucent ground shadow at an isometric grid cell's surface centre.
+fn drawGroundShadow(gridX: f32, gridY: f32, gridOffset: rl.Vector2, gridScale: f32, radiusScale: f32, alphaScale: f32) void {
+    const tilePos = utils.isoToXY(gridX, gridY, 32, 32, gridOffset.x, gridOffset.y, gridScale);
+    const cx = tilePos.x + 16 * gridScale;
+    const cy = tilePos.y + 8 * gridScale;
+    const rx = 26 * radiusScale * (gridScale / 3.0);
+    const ry = rx * 0.5;
+    drawEllipseSoft(cx, cy, rx, ry, @intFromFloat(alphaScale * 255));
+}
+
+fn drawEllipseSoft(cx: f32, cy: f32, rx: f32, ry: f32, alpha: u8) void {
+    rl.drawEllipse(@intFromFloat(cx), @intFromFloat(cy), rx, ry, rl.Color.init(0, 0, 0, alpha));
 }
 
 fn buildBeeRenderList(world: *World) void {
@@ -183,20 +232,25 @@ fn buildBeeRenderList(world: *World) void {
     }
 }
 
-fn drawSpriteAtGridPosition(texture: rl.Texture, i: f32, j: f32, sourceRect: rl.Rectangle, scale: f32, color: rl.Color, gridOffset: rl.Vector2, gridScale: f32) void {
+fn drawSpriteAtGridPosition(texture: rl.Texture, i: f32, j: f32, sourceRect: rl.Rectangle, scale: f32, color: rl.Color, gridOffset: rl.Vector2, gridScale: f32, swayDeg: f32) void {
     const tilePosition = utils.isoToXY(i, j, 32, 32, gridOffset.x, gridOffset.y, gridScale);
     const effectiveScale = scale * (gridScale / 3.0);
     const tileWidth = 32 * gridScale;
     const tileHeight = 32 * gridScale;
 
-    const centeredX = tilePosition.x + (tileWidth - sourceRect.width * effectiveScale) / 2.0;
-    const centeredY = tilePosition.y + (tileHeight * 0.25) - (sourceRect.height * effectiveScale);
-    const destination = rl.Rectangle.init(centeredX, centeredY, sourceRect.width * effectiveScale, sourceRect.height * effectiveScale);
+    const destW = sourceRect.width * effectiveScale;
+    const destH = sourceRect.height * effectiveScale;
+    const centeredX = tilePosition.x + (tileWidth - destW) / 2.0;
+    const centeredY = tilePosition.y + (tileHeight * 0.25) - destH;
 
-    rl.drawTexturePro(texture, sourceRect, destination, rl.Vector2.init(0, 0), 0, color);
+    // Pivot the sway around the flower's base (bottom-centre) so it bends like a
+    // stem in the breeze rather than sliding.
+    const destination = rl.Rectangle.init(centeredX + destW / 2.0, centeredY + destH, destW, destH);
+    const origin = rl.Vector2.init(destW / 2.0, destH);
+    rl.drawTexturePro(texture, sourceRect, destination, origin, swayDeg, color);
 }
 
-fn drawBeehiveAtGridPosition(texture: rl.Texture, i: f32, j: f32, width: f32, height: f32, scale: f32, gridOffset: rl.Vector2, gridScale: f32) void {
+fn drawBeehiveAtGridPosition(texture: rl.Texture, i: f32, j: f32, width: f32, height: f32, scale: f32, gridOffset: rl.Vector2, gridScale: f32, tint: rl.Color) void {
     const tilePosition = utils.isoToXY(i, j, 32, 32, gridOffset.x, gridOffset.y, gridScale);
     const effectiveScale = scale * (gridScale / 3.0);
     const tileWidth = 32 * gridScale;
@@ -207,7 +261,7 @@ fn drawBeehiveAtGridPosition(texture: rl.Texture, i: f32, j: f32, width: f32, he
     const source = rl.Rectangle.init(0, 0, width, height);
     const destination = rl.Rectangle.init(centeredX, centeredY, width * effectiveScale, height * effectiveScale);
 
-    rl.drawTexturePro(texture, source, destination, rl.Vector2.init(0, 0), 0, rl.Color.white);
+    rl.drawTexturePro(texture, source, destination, rl.Vector2.init(0, 0), 0, tint);
 }
 
 fn drawRebirthBubble(gridX: f32, gridY: f32, gridOffset: rl.Vector2, gridScale: f32, time: f32) void {

--- a/src/floating_text.zig
+++ b/src/floating_text.zig
@@ -23,7 +23,7 @@ pub const Manager = struct {
     allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator) @This() {
-        return .{ .items = .{}, .allocator = allocator };
+        return .{ .items = .empty, .allocator = allocator };
     }
 
     pub fn deinit(self: *@This()) void {

--- a/src/game.zig
+++ b/src/game.zig
@@ -16,6 +16,9 @@ const floating_text = @import("floating_text.zig");
 const upgrade_tree = @import("upgrade_tree.zig");
 const labs = @import("labs.zig");
 const prestige_mod = @import("prestige.zig");
+const Sky = @import("sky.zig").Sky;
+const Ambient = @import("ambient.zig").Ambient;
+const Audio = @import("audio.zig").Audio;
 
 const World = @import("ecs/world.zig").World;
 const components = @import("ecs/components.zig");
@@ -47,6 +50,9 @@ pub const Game = struct {
 
     textures: Textures,
     grid: Grid,
+    sky: Sky,
+    ambient: Ambient,
+    audio: Audio,
 
     world: World,
 
@@ -87,19 +93,35 @@ pub const Game = struct {
     state: GameState,
 
     allocator: std.mem.Allocator,
+    env: *std.process.Environ.Map,
 
-    pub fn init(allocator: std.mem.Allocator) !@This() {
-        const rand = std.crypto.random;
-        rl.setRandomSeed(rand.int(u32));
+    pub fn init(allocator: std.mem.Allocator, io: std.Io, env: *std.process.Environ.Map) !@This() {
+        // Seed raylib's RNG from the wall clock (std.crypto.random was removed in 0.16;
+        // time is now read through an Io clock).
+        const nowTs = std.Io.Clock.now(.real, io);
+        const seed: u96 = @bitCast(nowTs.nanoseconds);
+        rl.setRandomSeed(@truncate(seed));
 
-        const monitor = rl.getCurrentMonitor();
-        const screenWidth = rl.getMonitorWidth(monitor);
-        const screenHeight = rl.getMonitorHeight(monitor);
-
-        rl.initWindow(screenWidth, screenHeight, "Buzzness Tycoon");
+        // Monitor queries only work once GLFW is up, so open a default-size
+        // window first, then size it to the monitor. (Querying before
+        // initWindow returns 0 on raylib 6 → an 800x450 fallback window.)
+        rl.initWindow(1280, 720, "Buzzness Tycoon");
         rl.setExitKey(rl.KeyboardKey.null); // Disable default ESC closing the window
         rl.setWindowState(.{ .window_resizable = true });
-        rl.toggleFullscreen();
+        // Dev: BT_WINDOWED runs in a plain window (no fullscreen takeover) so
+        // the game can be launched/screenshotted without hijacking the desktop.
+        if (env.get("BT_WINDOWED") == null) {
+            const monitor = rl.getCurrentMonitor();
+            const mw = rl.getMonitorWidth(monitor);
+            const mh = rl.getMonitorHeight(monitor);
+            if (mw > 0 and mh > 0) rl.setWindowSize(mw, mh);
+            rl.toggleFullscreen();
+        } else {
+            rl.setWindowSize(1366, 820);
+        }
+        if (env.get("BT_PHASE")) |p| {
+            Sky.phaseOverride = std.fmt.parseFloat(f32, p) catch null;
+        }
         const windowIcon = try assets.loadImageFromMemory(assets.bee_png);
         rl.setWindowIcon(windowIcon);
 
@@ -140,11 +162,14 @@ pub const Game = struct {
 
             .textures = textures,
             .grid = grid,
+            .sky = Sky.init(),
+            .ambient = Ambient.init(),
+            .audio = Audio.init(allocator),
             .world = world,
 
             .resources = Resources.init(),
             .hud = ui.Hud.init(),
-            .metrics = Metrics.init(),
+            .metrics = Metrics.init(io),
             .floatingTexts = floating_text.Manager.init(allocator),
             .upgradeTree = upgrade_tree.State.init(allocator),
             .showTree = false,
@@ -171,7 +196,8 @@ pub const Game = struct {
             .isPaused = false,
             .shouldExit = false,
 
-            .state = .title_screen,
+            .state = if (env.get("BT_AUTOPLAY") != null) .playing else .title_screen,
+            .env = env,
 
             .width = width,
             .height = height,
@@ -188,6 +214,7 @@ pub const Game = struct {
         self.metrics.deinit();
         self.floatingTexts.deinit();
         self.upgradeTree.deinit();
+        self.audio.deinit();
         ui.title_screen.deinit();
 
         rl.closeWindow();
@@ -195,6 +222,14 @@ pub const Game = struct {
     }
 
     pub fn run(self: *@This()) !void {
+        // Dev: BT_SHOOT=N renders N frames, writes a screenshot, then exits.
+        const shootAt: ?u32 = blk: {
+            const v = self.env.get("BT_SHOOT") orelse break :blk null;
+            break :blk std.fmt.parseInt(u32, v, 10) catch null;
+        };
+        if (shootAt != null) rl.setTargetFPS(60);
+        var frame: u32 = 0;
+
         while (!rl.windowShouldClose() and !self.shouldExit) {
             self.handleCommonInput();
             switch (self.state) {
@@ -205,11 +240,23 @@ pub const Game = struct {
                     try self.draw();
                 },
             }
+
+            frame += 1;
+            if (shootAt) |n| {
+                if (frame >= n) {
+                    rl.takeScreenshot("bt_shot.png");
+                    self.shouldExit = true;
+                }
+            }
         }
     }
 
     /// Handle input common to all game states (fullscreen, window resize)
     fn handleCommonInput(self: *@This()) void {
+        // Keep the ambient audio bed looping in every state, and allow muting.
+        self.audio.update(rl.getFrameTime());
+        if (rl.isKeyPressed(rl.KeyboardKey.n)) self.audio.toggleMute();
+
         // Alt+Enter to toggle fullscreen
         if (rl.isKeyPressed(rl.KeyboardKey.enter) and rl.isKeyDown(rl.KeyboardKey.left_alt)) {
             const wasFullscreen = rl.isWindowFullscreen();
@@ -237,6 +284,12 @@ pub const Game = struct {
         defer rl.endDrawing();
 
         rl.clearBackground(theme.CatppuccinMocha.Color.base);
+
+        // Cozy animated sky behind the title, with a subtle darkening wash so
+        // the menu text stays readable.
+        self.sky.drawBackground(self.width, self.height);
+        self.sky.drawCelestial(self.width, self.height);
+        rl.drawRectangle(0, 0, @intFromFloat(self.width), @intFromFloat(self.height), rl.Color.init(20, 20, 40, 90));
 
         const action = ui.title_screen.draw(self.width, self.height);
         switch (action) {
@@ -422,8 +475,10 @@ pub const Game = struct {
             const centerX: f32 = @floatFromInt((self.gridWidth - 1) / 2);
             const centerY: f32 = @floatFromInt((self.gridHeight - 1) / 2);
             try self.floatingTexts.spawn(centerX, centerY, frameHoneyGain);
+            self.audio.playCollect();
         }
         self.floatingTexts.update(deltaTime);
+        self.ambient.update(deltaTime, self.width - ui.side_panel.PANEL_WIDTH, self.height);
 
         try self.world.processDestroyQueue();
     }
@@ -434,11 +489,23 @@ pub const Game = struct {
 
         rl.clearBackground(theme.CatppuccinMocha.Color.base);
 
-        self.grid.draw();
+        // Cozy animated sky behind everything.
+        self.sky.drawBackground(self.width, self.height);
 
-        try render_system.draw(&self.world, self.grid.offset, self.grid.scale);
+        self.grid.draw(self.sky.worldTint());
+
+        try render_system.draw(&self.world, self.grid.offset, self.grid.scale, self.sky.worldTint());
 
         self.floatingTexts.draw(self.grid.offset, self.grid.scale);
+
+        // Ambient day/night light wash + vignette over the whole meadow.
+        self.sky.drawAmbientOverlay(self.width, self.height);
+
+        // Sun/moon on top of the wash so they stay bright and crisp.
+        self.sky.drawCelestial(self.width, self.height);
+
+        // Floating pollen dust / fireflies over the light wash so they glow.
+        self.ambient.draw(self.sky.nightFactor());
 
         // Draw HUD (reuses this frame's cached factor)
         const honeyFactor = self.cachedHoneyFactor;

--- a/src/grid.zig
+++ b/src/grid.zig
@@ -85,7 +85,7 @@ pub const Grid = struct {
         rl.unloadTexture(self.tileTexture);
     }
 
-    pub fn draw(self: @This()) void {
+    pub fn draw(self: @This(), tint: rl.Color) void {
         const screenWidth: f32 = @floatFromInt(rl.getScreenWidth());
         const screenHeight: f32 = @floatFromInt(rl.getScreenHeight());
         const margin: f32 = 64 * self.scale;
@@ -105,8 +105,8 @@ pub const Grid = struct {
                 }
 
                 const isHovered = if (hovered) |h| (h.x == @as(i32, @intCast(i)) and h.y == @as(i32, @intCast(j))) else false;
-                const color = if (isHovered) rl.Color.red else rl.Color.white;
-                rl.drawTextureEx(self.tileTexture, position, 0, self.scale, color);
+                const base = if (isHovered) rl.Color.red else rl.Color.white;
+                rl.drawTextureEx(self.tileTexture, position, 0, self.scale, rl.colorTint(base, tint));
             }
         }
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,12 +1,10 @@
 const std = @import("std");
-const rl = @import("raylib");
 const Game = @import("game.zig").Game;
 
-pub fn main() anyerror!void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = gpa.allocator();
-
-    var game = try Game.init(allocator);
+// Zig 0.16 entry point: `Init` hands us a ready allocator, an Io implementation,
+// and the process environment — no manual GPA/Threaded setup needed.
+pub fn main(init: std.process.Init) !void {
+    var game = try Game.init(init.gpa, init.io, init.environ_map);
     defer game.deinit();
 
     try game.run();

--- a/src/metrics.zig
+++ b/src/metrics.zig
@@ -6,22 +6,24 @@ fn isLeapYear(year: u64) bool {
 }
 
 pub const Metrics = struct {
-    file: ?std.fs.File,
+    io: std.Io,
+    file: ?std.Io.File,
     frameCounter: u32,
     lastLogTime: f64,
 
     const LOG_INTERVAL_SECONDS: f64 = 1.0;
     const SPIKE_THRESHOLD_MS: f32 = 33.0;
 
-    pub fn init() @This() {
-        std.fs.cwd().makeDir("logs") catch |err| {
+    pub fn init(io: std.Io) @This() {
+        // Zig 0.16 threads an `Io` through file operations (the std I/O refactor).
+        std.Io.Dir.cwd().createDirPath(io, "logs") catch |err| {
             if (err != error.PathAlreadyExists) {
                 std.debug.print("Failed to create logs directory: {}\n", .{err});
-                return .{ .file = null, .frameCounter = 0, .lastLogTime = 0 };
+                return .{ .io = io, .file = null, .frameCounter = 0, .lastLogTime = 0 };
             }
         };
 
-        const timestamp = std.time.timestamp();
+        const timestamp: i64 = @intCast(@divTrunc(std.Io.Clock.now(.real, io).nanoseconds, std.time.ns_per_s));
         const epochSeconds: u64 = @intCast(timestamp);
         const epochSeconds2000: u64 = epochSeconds - 946684800;
 
@@ -60,20 +62,20 @@ pub const Metrics = struct {
             year, month, day, hours, minutes, seconds,
         }) catch "logs/metrics.csv";
 
-        const file = std.fs.cwd().createFile(filename, .{}) catch |err| {
+        const file = std.Io.Dir.cwd().createFile(io, filename, .{}) catch |err| {
             std.debug.print("Failed to create metrics file: {}\n", .{err});
-            return .{ .file = null, .frameCounter = 0, .lastLogTime = 0 };
+            return .{ .io = io, .file = null, .frameCounter = 0, .lastLogTime = 0 };
         };
 
-        _ = file.write("timestamp_ms,fps,frame_time_ms,bee_count,flower_count,is_spike\n") catch {};
+        file.writeStreamingAll(io, "timestamp_ms,fps,frame_time_ms,bee_count,flower_count,is_spike\n") catch {};
         std.debug.print("Metrics logging to: {s}\n", .{filename});
 
-        return .{ .file = file, .frameCounter = 0, .lastLogTime = 0 };
+        return .{ .io = io, .file = file, .frameCounter = 0, .lastLogTime = 0 };
     }
 
     pub fn deinit(self: *@This()) void {
         if (self.file) |file| {
-            file.close();
+            file.close(self.io);
         }
     }
 
@@ -87,14 +89,14 @@ pub const Metrics = struct {
         const isSpike = frameTimeMs >= SPIKE_THRESHOLD_MS;
 
         if (timeSinceLastLog >= LOG_INTERVAL_SECONDS or isSpike) {
-            const timestamp = std.time.milliTimestamp();
+            const timestamp: i64 = @intCast(@divTrunc(std.Io.Clock.now(.real, self.io).nanoseconds, std.time.ns_per_ms));
 
             var buf: [128]u8 = undefined;
             const line = std.fmt.bufPrint(&buf, "{d},{d:.1},{d:.2},{d},{d},{}\n", .{
                 timestamp, fps, frameTimeMs, beeCount, flowerCount, isSpike,
             }) catch return;
 
-            _ = self.file.?.write(line) catch {};
+            self.file.?.writeStreamingAll(self.io, line) catch {};
             self.lastLogTime = currentTime;
         }
     }

--- a/src/sky.zig
+++ b/src/sky.zig
@@ -1,0 +1,249 @@
+const rl = @import("raylib");
+const std = @import("std");
+
+/// Cozy animated sky + day/night cycle.
+///
+/// Everything is driven off `rl.getTime()` so it needs no per-frame state
+/// threading — the whole atmosphere is a pure function of the wall clock.
+/// A full day/night cycle takes DAY_LENGTH seconds. Kept long and gentle so
+/// the game reads as calm and AFK-friendly rather than a strobing disco.
+pub const Sky = struct {
+    pub const DAY_LENGTH: f32 = 300.0; // seconds for a full dawn→night→dawn loop
+    const STAR_COUNT = 140;
+    const CLOUD_COUNT = 7;
+
+    // Start the world a little after sunrise so the first thing the player
+    // sees is a bright, welcoming morning.
+    const START_PHASE: f32 = 0.30;
+
+    const Star = struct { x: f32, y: f32, size: f32, phase: f32 };
+    const Cloud = struct { x: f32, y: f32, scale: f32, speed: f32, alpha: f32 };
+
+    stars: [STAR_COUNT]Star,
+    clouds: [CLOUD_COUNT]Cloud,
+
+    // Deterministic little RNG so the sky layout is stable and doesn't disturb
+    // raylib's global RNG (which the gameplay relies on).
+    fn lcg(state: *u32) f32 {
+        state.* = state.* *% 1664525 +% 1013904223;
+        return @as(f32, @floatFromInt(state.* >> 8)) / @as(f32, @floatFromInt(1 << 24));
+    }
+
+    pub fn init() Sky {
+        var s: Sky = undefined;
+        var rng: u32 = 0x9e3779b9;
+
+        for (&s.stars) |*star| {
+            star.x = lcg(&rng);
+            star.y = lcg(&rng) * 0.6; // upper 60% of the sky
+            star.size = 0.6 + lcg(&rng) * 1.6;
+            star.phase = lcg(&rng) * std.math.tau;
+        }
+        for (&s.clouds) |*cloud| {
+            cloud.x = lcg(&rng);
+            cloud.y = 0.05 + lcg(&rng) * 0.4;
+            cloud.scale = 0.6 + lcg(&rng) * 1.1;
+            cloud.speed = 0.004 + lcg(&rng) * 0.010;
+            cloud.alpha = 0.35 + lcg(&rng) * 0.4;
+        }
+        return s;
+    }
+
+    /// Dev/screenshot hook: when set, freezes the clock at this phase.
+    pub var phaseOverride: ?f32 = null;
+
+    /// Normalized time of day in [0,1): 0 = midnight, 0.25 = sunrise,
+    /// 0.5 = noon, 0.75 = sunset.
+    pub fn timeOfDay(_: *const Sky) f32 {
+        if (phaseOverride) |p| return @mod(p, 1.0);
+        const t = @as(f32, @floatCast(rl.getTime()));
+        return @mod(t / DAY_LENGTH + START_PHASE, 1.0);
+    }
+
+    /// Sun elevation in [-1,1]. >0 is above the horizon (daytime).
+    pub fn sunElevation(self: *const Sky) f32 {
+        return -@cos(self.timeOfDay() * std.math.tau);
+    }
+
+    /// 0 = full day, 1 = deep night. Smooth around the horizon crossings.
+    pub fn nightFactor(self: *const Sky) f32 {
+        return smoothstep(0.10, -0.20, self.sunElevation());
+    }
+
+    // ---- gradient keyframes -------------------------------------------------
+
+    const Key = struct { pos: f32, top: [3]f32, hor: [3]f32 };
+    const KEYS = [_]Key{
+        .{ .pos = 0.00, .top = .{ 12, 12, 30 }, .hor = .{ 30, 26, 56 } }, // midnight
+        .{ .pos = 0.20, .top = .{ 34, 30, 66 }, .hor = .{ 70, 50, 92 } }, // pre-dawn
+        .{ .pos = 0.25, .top = .{ 78, 92, 146 }, .hor = .{ 244, 156, 112 } }, // sunrise
+        .{ .pos = 0.33, .top = .{ 126, 168, 214 }, .hor = .{ 250, 214, 176 } }, // morning
+        .{ .pos = 0.50, .top = .{ 120, 178, 228 }, .hor = .{ 206, 228, 236 } }, // noon
+        .{ .pos = 0.67, .top = .{ 128, 158, 210 }, .hor = .{ 250, 208, 154 } }, // afternoon
+        .{ .pos = 0.75, .top = .{ 96, 74, 138 }, .hor = .{ 246, 122, 92 } }, // sunset
+        .{ .pos = 0.82, .top = .{ 48, 38, 84 }, .hor = .{ 122, 62, 96 } }, // dusk
+        .{ .pos = 1.00, .top = .{ 12, 12, 30 }, .hor = .{ 30, 26, 56 } }, // midnight
+    };
+
+    fn sampleGradient(t: f32) struct { top: rl.Color, hor: rl.Color } {
+        var i: usize = 0;
+        while (i + 1 < KEYS.len and t > KEYS[i + 1].pos) : (i += 1) {}
+        const a = KEYS[i];
+        const b = KEYS[@min(i + 1, KEYS.len - 1)];
+        const span = @max(0.0001, b.pos - a.pos);
+        const f = std.math.clamp((t - a.pos) / span, 0.0, 1.0);
+        return .{
+            .top = lerpRGB(a.top, b.top, f),
+            .hor = lerpRGB(a.hor, b.hor, f),
+        };
+    }
+
+    // ---- drawing ------------------------------------------------------------
+
+    /// Full-screen background: gradient sky, stars, celestial bodies, clouds.
+    /// Call right after beginDrawing(), before the world.
+    pub fn drawBackground(self: *const Sky, width: f32, height: f32) void {
+        const t = self.timeOfDay();
+        const grad = sampleGradient(t);
+        const w: i32 = @intFromFloat(width);
+        const h: i32 = @intFromFloat(height);
+
+        // Two-band gradient: sky top → warm horizon, with a subtle darker
+        // lower band so the floating island reads against it.
+        const horizonY: f32 = height * 0.60;
+        rl.drawRectangleGradientV(0, 0, w, @intFromFloat(horizonY), grad.top, grad.hor);
+        const lower = rl.colorLerp(grad.hor, grad.top, 0.55);
+        rl.drawRectangleGradientV(0, @intFromFloat(horizonY), w, h - @as(i32, @intFromFloat(horizonY)), grad.hor, lower);
+
+        const night = self.nightFactor();
+        const time = @as(f32, @floatCast(rl.getTime()));
+
+        // Stars — fade in with night, gentle twinkle.
+        if (night > 0.02) {
+            for (self.stars) |star| {
+                const tw = 0.55 + 0.45 * @sin(time * 1.8 + star.phase);
+                const a = night * tw;
+                if (a <= 0.02) continue;
+                const col = rl.Color.init(240, 240, 255, @intFromFloat(std.math.clamp(a, 0, 1) * 235));
+                rl.drawCircle(@intFromFloat(star.x * width), @intFromFloat(star.y * height), star.size, col);
+            }
+        }
+
+        self.drawSun(width, height, horizonY);
+        self.drawClouds(width, night, time);
+    }
+
+    /// Sun/moon, drawn as a foreground pass (after the ambient light wash) so
+    /// Sun, drawn in the background pass so it rises/sets *behind* the floating
+    /// island. Daytime has no night veil, so it stays bright without a
+    /// foreground pass.
+    fn drawSun(self: *const Sky, width: f32, height: f32, horizonY: f32) void {
+        const t = self.timeOfDay();
+        const e = self.sunElevation();
+        const arc = height * 0.46;
+        if (e <= -0.12) return;
+        const dayX = std.math.clamp((t - 0.25) / 0.5, -0.15, 1.15);
+        const sx = width * (0.12 + 0.76 * dayX);
+        const sy = horizonY - e * arc;
+        const glow = std.math.clamp(e + 0.3, 0.0, 1.0);
+        rl.drawCircleGradient(rl.Vector2.init(sx, sy), 120, rl.Color.init(255, 226, 150, @intFromFloat(80 * glow)), rl.Color.init(255, 226, 150, 0));
+        rl.drawCircle(@intFromFloat(sx), @intFromFloat(sy), 30, rl.Color.init(255, 244, 214, 255));
+        rl.drawCircle(@intFromFloat(sx), @intFromFloat(sy), 23, rl.Color.init(255, 236, 170, 255));
+    }
+
+    /// they stay bright and crisp instead of being muted by the night veil.
+    /// Foreground pass: just the moon (drawn after the ambient wash so it stays
+    /// crisp at night). The sun lives in the background pass, see drawSun.
+    pub fn drawCelestial(self: *const Sky, width: f32, height: f32) void {
+        const horizonY: f32 = height * 0.60;
+        const e = self.sunElevation();
+        const t = self.timeOfDay();
+        const arc = height * 0.46;
+
+        // Moon: opposite the sun, a soft full moon with a wide gentle halo.
+        const me = -e;
+        if (me > -0.05) {
+            const mt = @mod(t + 0.5, 1.0);
+            const nightX = std.math.clamp((mt - 0.25) / 0.5, -0.15, 1.15);
+            const mx = width * (0.12 + 0.76 * nightX);
+            const my = horizonY - me * arc;
+            const vis = std.math.clamp(me + 0.05, 0.0, 1.0);
+            rl.drawCircleGradient(rl.Vector2.init(mx, my), 110, rl.Color.init(210, 222, 255, @intFromFloat(38 * vis)), rl.Color.init(210, 222, 255, 0));
+            rl.drawCircle(@intFromFloat(mx), @intFromFloat(my), 30, rl.Color.init(226, 232, 255, @intFromFloat(70 * vis)));
+            rl.drawCircle(@intFromFloat(mx), @intFromFloat(my), 24, rl.Color.init(240, 244, 255, @intFromFloat(255 * vis)));
+            // A couple of faint craters for character.
+            const crater = rl.Color.init(206, 214, 244, @intFromFloat(255 * vis));
+            rl.drawCircle(@intFromFloat(mx - 8), @intFromFloat(my - 6), 4, crater);
+            rl.drawCircle(@intFromFloat(mx + 7), @intFromFloat(my + 5), 5, crater);
+            rl.drawCircle(@intFromFloat(mx + 2), @intFromFloat(my - 9), 3, crater);
+        }
+    }
+
+    fn drawClouds(self: *const Sky, width: f32, night: f32, time: f32) void {
+        // Clouds go grey-blue and dim at night.
+        const bright: u8 = @intFromFloat(255 - night * 130);
+        for (self.clouds) |cloud| {
+            const drift = @mod(cloud.x + time * cloud.speed, 1.2) - 0.1;
+            const cx = drift * width;
+            const cy = cloud.y * width * 0.34;
+            const s = cloud.scale;
+            const a: u8 = @intFromFloat(cloud.alpha * (1.0 - night * 0.55) * 255);
+            const col = rl.Color.init(bright, bright, @min(255, @as(u16, bright) + 8), a);
+            // A puff = a few overlapping soft ellipses.
+            rl.drawEllipse(@intFromFloat(cx), @intFromFloat(cy), 46 * s, 22 * s, col);
+            rl.drawEllipse(@intFromFloat(cx - 34 * s), @intFromFloat(cy + 8 * s), 32 * s, 17 * s, col);
+            rl.drawEllipse(@intFromFloat(cx + 36 * s), @intFromFloat(cy + 9 * s), 30 * s, 16 * s, col);
+            rl.drawEllipse(@intFromFloat(cx + 6 * s), @intFromFloat(cy - 10 * s), 30 * s, 18 * s, col);
+        }
+    }
+
+    /// Ambient lighting veil + vignette, drawn over the world (after sprites,
+    /// before the HUD) so the whole meadow shares one light. Cheap: a couple
+    /// of translucent full-screen passes.
+    pub fn drawAmbientOverlay(self: *const Sky, width: f32, height: f32) void {
+        const w: i32 = @intFromFloat(width);
+        const h: i32 = @intFromFloat(height);
+        const e = self.sunElevation();
+        const night = self.nightFactor();
+
+        // Cool night veil.
+        if (night > 0.01) {
+            rl.drawRectangle(0, 0, w, h, rl.Color.init(20, 24, 60, @intFromFloat(night * 120)));
+        }
+        // Warm twilight wash around sunrise/sunset (peaks when sun near horizon).
+        const twilight = std.math.clamp(1.0 - @abs(e) * 4.0, 0.0, 1.0);
+        if (twilight > 0.01) {
+            rl.drawRectangle(0, 0, w, h, rl.Color.init(255, 150, 90, @intFromFloat(twilight * 42)));
+        }
+        // Gentle always-on vignette for cozy framing.
+        const r = @max(width, height) * 0.75;
+        rl.drawCircleGradient(rl.Vector2.init(width * 0.5, height * 0.5), r, rl.Color.init(0, 0, 0, 0), rl.Color.init(0, 0, 0, 70));
+    }
+
+    /// Tint applied to world sprites so bees/flowers pick up the ambient light.
+    pub fn worldTint(self: *const Sky) rl.Color {
+        const e = self.sunElevation();
+        const night = self.nightFactor();
+        // Warm daylight → dim cool moonlight, with a golden push near the horizon.
+        const day = rl.Color.init(255, 250, 240, 255);
+        const nightCol = rl.Color.init(150, 165, 210, 255);
+        var tint = rl.colorLerp(day, nightCol, night * 0.85);
+        const golden = std.math.clamp(1.0 - @abs(e) * 4.0, 0.0, 1.0) * 0.5;
+        if (golden > 0.01) tint = rl.colorLerp(tint, rl.Color.init(255, 198, 150, 255), golden);
+        return tint;
+    }
+};
+
+fn smoothstep(edge0: f32, edge1: f32, x: f32) f32 {
+    const t = std.math.clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+    return t * t * (3.0 - 2.0 * t);
+}
+
+fn lerpRGB(a: [3]f32, b: [3]f32, f: f32) rl.Color {
+    return rl.Color.init(
+        @intFromFloat(std.math.clamp(a[0] + (b[0] - a[0]) * f, 0, 255)),
+        @intFromFloat(std.math.clamp(a[1] + (b[1] - a[1]) * f, 0, 255)),
+        @intFromFloat(std.math.clamp(a[2] + (b[2] - a[2]) * f, 0, 255)),
+        255,
+    );
+}


### PR DESCRIPTION
Adds a day/night cycle, living-world motion/shadows, fireflies and procedural audio, and brings the project onto **Zig 0.16** (raylib_zig 6.0.0). CI pinned to 0.16.0.

Opening this PR to exercise the build workflow and confirm the Linux + Windows artifacts generate correctly on `ubuntu-latest`. Verified locally: `zig build` (Debug), `zig build -Doptimize=ReleaseFast` (Linux ELF) and `zig build -Dtarget=x86_64-windows -Doptimize=ReleaseFast` (PE32+ .exe) all produce working artifacts at the CI paths.

Also fixes a latent bug: monitor size was queried before `initWindow`, giving an 800x450 fallback window on raylib 6.